### PR TITLE
[#11195] ShipHawk simplification of barcode

### DIFF
--- a/lib/zebra/zpl/barcode.rb
+++ b/lib/zebra/zpl/barcode.rb
@@ -11,7 +11,7 @@ module Zebra
       class InvalidNarrowBarWidthError < StandardError; end
       class InvalidWideBarWidthError   < StandardError; end
 
-      attr_accessor :height, :application_identifier
+      attr_accessor :height
       attr_reader :type, :ratio, :narrow_bar_width, :wide_bar_width
       attr_writer :print_human_readable_code, :print_text_above
 
@@ -69,21 +69,17 @@ module Zebra
 
       # ShipHawk trick: Start
       def mode
-        if application_identifier || data.to_s.match?(APPLICATION_IDENTIFIER_REGEX)
+        if data.to_s.match?(APPLICATION_IDENTIFIER_REGEX)
           'D'
         else
           'A'
         end
       end
-
-      def mode_prefix
-        application_identifier ? "(#{application_identifier})" : nil
-      end
       # ShipHawk trick: End
 
       def to_zpl
         check_attributes
-        "^FW#{rotation}^FO#{x},#{y}^BY#{width},#{ratio},#{height}^B#{type}#{rotation},,#{human_readable},#{text_above},,#{mode}^FD#{mode_prefix}#{data}^FS"
+        "^FW#{rotation}^FO#{x},#{y}^BY#{width},#{ratio},#{height}^B#{type}#{rotation},,#{human_readable},#{text_above},,#{mode}^FD#{data}^FS"
       end
 
       private

--- a/lib/zebra/zpl/graphic.rb
+++ b/lib/zebra/zpl/graphic.rb
@@ -72,6 +72,8 @@ module Zebra
         when "S"
           sym = !symbol_type.nil? ? "^FD#{symbol_type}" : ''
           "S,#{graphic_height},#{graphic_width}#{sym}"
+        else
+          raise InvalidGraphicType
         end
         "^FW#{rotation}^FO#{x},#{y}^G#{graphic}^FS"
       end

--- a/lib/zebra/zpl/text.rb
+++ b/lib/zebra/zpl/text.rb
@@ -66,8 +66,8 @@ module Zebra
         if bold.nil?
           "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS"
         else
-          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x+2},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS" +
-          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x},#{y+2}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS"
+          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x+1},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS" +
+          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x},#{y+1}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS"
         end
       end
 


### PR DESCRIPTION
## Ticket:
https://pm.shiphawk.com/issues/11195

## Description:
1. Removed SH application_id from gem source code.
2. Make bold a bit tiny:

<img width="527" alt="Screen Shot 2021-11-04 at 11 59 46" src="https://user-images.githubusercontent.com/1914001/140503161-a52817ea-0963-4351-9d53-f33ceab1ece4.png">


![label (1)](https://user-images.githubusercontent.com/1914001/140503902-ed3d52f4-a27c-450d-bef7-79133e1475ce.png)


